### PR TITLE
Update CEnum compat to include 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "CSyntax"
 uuid = "ea656a56-6ca6-5dda-bba5-7b6963a5f74c"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 
 [compat]
-CEnum = "0.4"
+CEnum = "0.4, 0.5"
 julia = "~1"
 
 [extras]


### PR DESCRIPTION
This package is holding back some of my other dependencies due to the CEnum compat. The bump we did to 0.5 shouldn't affect this package.